### PR TITLE
Feature: allow admin to change where current users are displayed on entry page

### DIFF
--- a/src/Presence.php
+++ b/src/Presence.php
@@ -28,7 +28,7 @@ class Presence extends Plugin
 
     public $hasCpSection = false;
 
-    public $hasCpSettings = false;
+    public $hasCpSettings = true;
 
     public $schemaVersion = '1.0.0';
 

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -13,4 +13,5 @@ use craft\base\Model;
 class Settings extends Model
 {
     public $refreshSessionToken = 6000;
+    public $displayContainer = '#details';
 }

--- a/src/resources/js/presence.js
+++ b/src/resources/js/presence.js
@@ -20,12 +20,12 @@
         /**
          * The constructor.
          */
-        init: function(userId, elementId)
+        init: function(userId, elementId, displayContainer)
         {
             this.userId = userId;
             this.elementId = elementId;
             setInterval($.proxy(this, 'isAlive'), 5000);
-            $("#details").append('<div id="enupal-presence" class="meta read-only hidden"></div>');
+            $(displayContainer).append('<div id="enupal-presence" class="meta read-only hidden"></div>');
         },
 
         hideElements: function(elements)

--- a/src/templates/_session/is-alive.twig
+++ b/src/templates/_session/is-alive.twig
@@ -2,6 +2,6 @@
 
 {% js %}
     $(document).ready(function() {
-    new EnupalPresence({{currentUser.id}}, {{ entryId }});
+        new EnupalPresence({{currentUser.id}}, {{ entryId }}, "{{ craft.presence.displayContainer }}");
     });
 {% endjs %}

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -20,3 +20,11 @@
     name: 'refreshSessionToken',
     errors: settings.getErrors('refreshSessionToken'),
     value: settings['refreshSessionToken']}) }}
+
+{{ forms.textField({
+    label: 'Display Container ID',
+    instructions: 'This is where current users will be displayed on an entry page (default is #details)',
+    id: 'displayContainer',
+    name: 'displayContainer',
+    errors: settings.getErrors('displayContainer'),
+    value: settings['displayContainer']}) }}

--- a/src/variables/PresenceVariable.php
+++ b/src/variables/PresenceVariable.php
@@ -13,5 +13,8 @@ use enupal\presence\Presence;
 
 class PresenceVariable
 {
+    public function displayContainer()
+    {
+        return Presence::getInstance()->settings->displayContainer;
+    }
 }
-


### PR DESCRIPTION
A client wants the current user box to appear at the top of the page (using #header-container) instead of at the bottom right

I would've done this with a config but the settings page was already set up so I enabled that and added it there!